### PR TITLE
Better image size

### DIFF
--- a/src/public/class-ifttt-instagram-gallery.php
+++ b/src/public/class-ifttt-instagram-gallery.php
@@ -340,7 +340,7 @@ class Ifttt_Instagram_Gallery {
 		$defaults = array(
 			'wrapper_width' => false,
 			'images_per_row' => 3,
-			'image_size' => 'thumbnail',
+			'image_size' => 'medium',
 			'random' => false,
 			'num_of_images' => false,
 		);


### PR DESCRIPTION
“thumbnail” size creates blurry image for container. “medium” provides
a proper image size.